### PR TITLE
Typo: license

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "template"
   ],
   "homepage": "https://github.com/zertosh/htmlescape",
-  "licence": "MIT",
+  "license": "MIT",
   "author": "Andres Suarez <zertosh@gmail.com>",
   "main": "htmlescape.js",
   "repository": {


### PR DESCRIPTION
Just a tiny fix for `package.json` so that automated license checkers like [nlf](https://www.npmjs.com/package/nlf) will work. Thanks!
